### PR TITLE
Re-export library `regex_syntax`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ use std::{
     string::FromUtf8Error,
 };
 
+// re-export
+pub use regex_syntax;
+
 const SHORT_UNICODE_CLASS_COUNT: usize = 64;
 
 /// Error returned by [`Regex::compile()`] and [`Regex::with_hir()`].
@@ -985,7 +988,9 @@ mod test {
             };
 
             let hir = parse(pattern).unwrap();
-            let HirKind::Class(Class::Unicode(cls)) = hir.into_kind() else { unreachable!() };
+            let HirKind::Class(Class::Unicode(cls)) = hir.into_kind() else {
+                unreachable!()
+            };
             // we assume all positive unicode classes do not cover the surrogate range.
             // otherwise `r.len()` is wrong.
             cls.iter().map(|r| r.len()).sum()


### PR DESCRIPTION
I simply added a re-export of library `regex_syntax` in lib.rs.
This way the user of this crate can always explicitely reference the correctly matching version of `regex_syntax` in his own software.
E.g.,
```rust
        match rand_regex::regex_syntax::ParserBuilder::new()
            .build()
            .parse(&terminal)
        {
            Ok(utf8_hir) => match rand_regex::Regex::with_hir(utf8_hir, MAX_REPEAT) {
                Ok(utf8_gen) => ...,
                Err(e) => ...,
            },
            Err(err) => ...,
        }
```
This enables the user to use a different version of `regex_syntax`. In my case I could update to version 8.2.
